### PR TITLE
Remove matplotlib inline magic

### DIFF
--- a/AGAVE/DL-python/perceptron/rosenblatt_perceptron.ipynb
+++ b/AGAVE/DL-python/perceptron/rosenblatt_perceptron.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import rosen\n",
     "import pylab as plt\n",
     "import numpy as np\n",

--- a/AGAVE/DL-python/pytorch/char_rnn_classification_tutorial.ipynb
+++ b/AGAVE/DL-python/pytorch/char_rnn_classification_tutorial.ipynb
@@ -11,7 +11,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/DL-python/pytorch/data_loading_tutorial.ipynb
+++ b/AGAVE/DL-python/pytorch/data_loading_tutorial.ipynb
@@ -11,7 +11,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/DL-python/pytorch/transfer_learning_tutorial.ipynb
+++ b/AGAVE/DL-python/pytorch/transfer_learning_tutorial.ipynb
@@ -11,7 +11,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/DL-python/rasbt/ch15_part1.ipynb
+++ b/AGAVE/DL-python/rasbt/ch15_part1.ipynb
@@ -92,7 +92,6 @@
    "outputs": [],
    "source": [
     "from IPython.display import Image\n",
-    "%matplotlib inline"
    ]
   },
   {
@@ -825,8 +824,6 @@
     "import pandas as pd\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
-   ]
   },
   {
    "cell_type": "code",

--- a/AGAVE/DL-python/rasbt/ch15_part2.ipynb
+++ b/AGAVE/DL-python/rasbt/ch15_part2.ipynb
@@ -63,7 +63,6 @@
     "from IPython.display import Image\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/ML-python/Raschka/ch04/ch04.ipynb
+++ b/AGAVE/ML-python/Raschka/ch04/ch04.ipynb
@@ -127,7 +127,6 @@
    "outputs": [],
    "source": [
     "from IPython.display import Image\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/ML-python/cuML/pca_demo.ipynb
+++ b/AGAVE/ML-python/cuML/pca_demo.ipynb
@@ -32,7 +32,6 @@
     "\n",
     "import pylab as plt\n",
     "from plt_style import *\n",
-    "%matplotlib inline\n",
     "\n",
     "import pandas as pd\n",
     "import cudf as gd\n",

--- a/AGAVE/ML-python/cuML/rapids.ipynb
+++ b/AGAVE/ML-python/cuML/rapids.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from plt_style import *\n",
     "from sklearn.datasets import make_circles\n",
     "import numpy,cupy\n",

--- a/AGAVE/ML-python/gpu/numba.ipynb
+++ b/AGAVE/ML-python/gpu/numba.ipynb
@@ -46,7 +46,6 @@
     "import numpy as np\n",
     "from numba import jit\n",
     "from plt_style import *\n",
-    "%matplotlib inline\n",
     "\n",
     "@jit\n",
     "def mandel(x, y, max_iters):\n",

--- a/AGAVE/ML-python/gpu/rapids_mandel.ipynb
+++ b/AGAVE/ML-python/gpu/rapids_mandel.ipynb
@@ -25,7 +25,6 @@
    "outputs": [],
    "source": [
     "# necessary imports\n",
-    "%matplotlib inline\n",
     "#import numpy as np\n",
     "import pylab as plt\n",
     "import cupy as np\n",

--- a/AGAVE/ML-python/pandas-and-wine/wine-data.ipynb
+++ b/AGAVE/ML-python/pandas-and-wine/wine-data.ipynb
@@ -20,7 +20,6 @@
     "import pylab as plt\n",
     "import seaborn as sns\n",
     "from plt_style import *\n",
-    "%matplotlib inline\n",
     "sns.set()"
    ]
   },

--- a/AGAVE/ML90-python/Raschka/ch01/ch01.ipynb
+++ b/AGAVE/ML90-python/Raschka/ch01/ch01.ipynb
@@ -24,7 +24,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "import pylab as plt\n",
     "import sys\n",

--- a/AGAVE/ML90-python/Raschka/ch04/ch04.ipynb
+++ b/AGAVE/ML90-python/Raschka/ch04/ch04.ipynb
@@ -78,7 +78,6 @@
     "import sys\n",
     "sys.path.append('../../common')\n",
     "import plt_style as ps\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/ML90-python/Raschka/ch15/ch15_part1.ipynb
+++ b/AGAVE/ML90-python/Raschka/ch15/ch15_part1.ipynb
@@ -86,7 +86,6 @@
    "outputs": [],
    "source": [
     "from IPython.display import Image\n",
-    "%matplotlib inline"
    ]
   },
   {
@@ -819,8 +818,6 @@
     "import pandas as pd\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
-   ]
   },
   {
    "cell_type": "code",

--- a/AGAVE/ML90-python/Raschka/ch15/ch15_part2.ipynb
+++ b/AGAVE/ML90-python/Raschka/ch15/ch15_part2.ipynb
@@ -63,7 +63,6 @@
     "from IPython.display import Image\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/ML90-python/cuML/pca_demo.ipynb
+++ b/AGAVE/ML90-python/cuML/pca_demo.ipynb
@@ -32,7 +32,6 @@
     "\n",
     "import pylab as plt\n",
     "from plt_style import *\n",
-    "%matplotlib inline\n",
     "\n",
     "import pandas as pd\n",
     "import cudf as gd\n",

--- a/AGAVE/ML90-python/cuML/rapids.ipynb
+++ b/AGAVE/ML90-python/cuML/rapids.ipynb
@@ -29,7 +29,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "import sys\n",
     "sys.path.append('../common')\n",
     "from plt_style import *\n",

--- a/AGAVE/ML90-python/fft-alignment-speed/fft-intel.ipynb
+++ b/AGAVE/ML90-python/fft-alignment-speed/fft-intel.ipynb
@@ -21,7 +21,6 @@
     "import numpy as np\n",
     "import pylab as plt\n",
     "import scipy as sp\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/ML90-python/fft-alignment-speed/fft-nvidia.ipynb
+++ b/AGAVE/ML90-python/fft-alignment-speed/fft-nvidia.ipynb
@@ -22,7 +22,6 @@
     "import cupy  as np\n",
     "import pylab as plt\n",
     "import scipy as sp\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/ML90-python/pandas-and-wine/wine-data.ipynb
+++ b/AGAVE/ML90-python/pandas-and-wine/wine-data.ipynb
@@ -20,7 +20,6 @@
     "import pylab as plt\n",
     "import seaborn as sns\n",
     "from plt_style import *\n",
-    "%matplotlib inline\n",
     "sns.set()"
    ]
   },

--- a/AGAVE/ML90-python/perceptron/rosenblatt_perceptron.ipynb
+++ b/AGAVE/ML90-python/perceptron/rosenblatt_perceptron.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import rosen\n",
     "import pylab as plt\n",
     "import numpy as np\n",

--- a/AGAVE/ML90-python/pytorch/transfer_learning_tutorial.ipynb
+++ b/AGAVE/ML90-python/pytorch/transfer_learning_tutorial.ipynb
@@ -11,7 +11,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/ML90-python/vis-discovery/vis-discovery.ipynb
+++ b/AGAVE/ML90-python/vis-discovery/vis-discovery.ipynb
@@ -23,7 +23,6 @@
    "outputs": [],
    "source": [
     "# Import required modules\n",
-    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import glob,natsort\n",

--- a/AGAVE/data-python/ls-example/least-squares-example.ipynb
+++ b/AGAVE/data-python/ls-example/least-squares-example.ipynb
@@ -42,7 +42,6 @@
     "import qp\n",
     "from numpy import *\n",
     "from pylab import *\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/data-python/numpy-example/Mandelbrot.ipynb
+++ b/AGAVE/data-python/numpy-example/Mandelbrot.ipynb
@@ -25,7 +25,6 @@
    "outputs": [],
    "source": [
     "# necessary imports\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "import pylab as plt"
    ]

--- a/AGAVE/data-python/ts-gen/ts-gen.ipynb
+++ b/AGAVE/data-python/ts-gen/ts-gen.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "import pylab as plt\n",
     "import natsort,glob\n",

--- a/AGAVE/data-python/vis-discovery/vis-discovery.ipynb
+++ b/AGAVE/data-python/vis-discovery/vis-discovery.ipynb
@@ -23,7 +23,6 @@
    "outputs": [],
    "source": [
     "# Import required modules\n",
-    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import glob,natsort\n",

--- a/AGAVE/intro-python/fft-gpu/fft-intel.ipynb
+++ b/AGAVE/intro-python/fft-gpu/fft-intel.ipynb
@@ -26,7 +26,6 @@
     "import numpy as np\n",
     "import pylab as plt\n",
     "import scipy as sp\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/intro-python/fft-gpu/fft-nvidia.ipynb
+++ b/AGAVE/intro-python/fft-gpu/fft-nvidia.ipynb
@@ -26,7 +26,6 @@
     "import cupy  as np\n",
     "import pylab as plt\n",
     "import scipy as sp\n",
-    "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'retina'"
    ]
   },

--- a/AGAVE/intro-python/fft-gpu/rapids.ipynb
+++ b/AGAVE/intro-python/fft-gpu/rapids.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from plt_style import *\n",
     "from sklearn.datasets import make_circles\n",
     "import numpy,cupy\n",

--- a/AGAVE/intro-python/heat/heat.ipynb
+++ b/AGAVE/intro-python/heat/heat.ipynb
@@ -42,7 +42,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "#from plt_style import *\n",
     "import heatnb as heat"
    ]

--- a/AGAVE/intro-python/lorenz/Lorenz Differential Equations.ipynb
+++ b/AGAVE/intro-python/lorenz/Lorenz Differential Equations.ipynb
@@ -44,7 +44,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
    ]
   },
   {

--- a/AGAVE/intro-python/lorenz/Lorenz.ipynb
+++ b/AGAVE/intro-python/lorenz/Lorenz.ipynb
@@ -20,7 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "#from plt_style import *\n",
     "from ipywidgets import interactive, fixed\n",
     "from IPython.display import clear_output, display, HTML"

--- a/AGAVE/intro-python/rapids/rapids.ipynb
+++ b/AGAVE/intro-python/rapids/rapids.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from plt_style import *\n",
     "from sklearn.datasets import make_circles\n",
     "import numpy,cupy\n",

--- a/AGAVE/intro-python/slides/IntroPython.ipynb
+++ b/AGAVE/intro-python/slides/IntroPython.ipynb
@@ -540,7 +540,6 @@
     "\n",
     "# plot the walk in the x-y plane\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
     "plt.plot(walk[:,0], walk[:,1])"
    ]
   },

--- a/AGAVE/intro-python/stats/stats.ipynb
+++ b/AGAVE/intro-python/stats/stats.ipynb
@@ -28,7 +28,6 @@
    "outputs": [],
    "source": [
     "# Standard module imports and Jupyter magics\n",
-    "%matplotlib inline\n",
     "import sys\n",
     "sys.path.append('../common')\n",
     "from plt_style import *\n",

--- a/DL-python/Raschka/ch01/ch01.ipynb
+++ b/DL-python/Raschka/ch01/ch01.ipynb
@@ -22,7 +22,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "import pylab as plt\n",
     "import sys\n",

--- a/DL-python/Raschka/ch15/ch15_part1.ipynb
+++ b/DL-python/Raschka/ch15/ch15_part1.ipynb
@@ -98,7 +98,6 @@
    "outputs": [],
    "source": [
     "from IPython.display import Image\n",
-    "%matplotlib inline"
    ]
   },
   {
@@ -809,8 +808,6 @@
     "import pandas as pd\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
-   ]
   },
   {
    "cell_type": "code",

--- a/DL-python/Raschka/ch15/ch15_part2.ipynb
+++ b/DL-python/Raschka/ch15/ch15_part2.ipynb
@@ -63,7 +63,6 @@
     "from IPython.display import Image\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/DL-python/perceptron/rosenblatt_perceptron.ipynb
+++ b/DL-python/perceptron/rosenblatt_perceptron.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import rosen\n",
     "import pylab as plt\n",
     "import numpy as np\n",

--- a/ML-python/Raschka/ch01/ch01.ipynb
+++ b/ML-python/Raschka/ch01/ch01.ipynb
@@ -22,7 +22,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "import pylab as plt\n",
     "import sys\n",

--- a/ML-python/Raschka/ch04/ch04.ipynb
+++ b/ML-python/Raschka/ch04/ch04.ipynb
@@ -78,7 +78,6 @@
     "import sys\n",
     "sys.path.append('../../common')\n",
     "import plt_style as ps\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/ML-python/Raschka/ch15/ch15_part1.ipynb
+++ b/ML-python/Raschka/ch15/ch15_part1.ipynb
@@ -98,7 +98,6 @@
    "outputs": [],
    "source": [
     "from IPython.display import Image\n",
-    "%matplotlib inline"
    ]
   },
   {
@@ -809,8 +808,6 @@
     "import pandas as pd\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
-   ]
   },
   {
    "cell_type": "code",

--- a/ML-python/Raschka/ch15/ch15_part2.ipynb
+++ b/ML-python/Raschka/ch15/ch15_part2.ipynb
@@ -63,7 +63,6 @@
     "from IPython.display import Image\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/ML-python/cuML/rapids.ipynb
+++ b/ML-python/cuML/rapids.ipynb
@@ -19,7 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import sys\n",
     "sys.path.append('../common')\n",
     "from plt_style import *\n",

--- a/ML-python/fft-alignment-speed/fft-CPU.ipynb
+++ b/ML-python/fft-alignment-speed/fft-CPU.ipynb
@@ -32,7 +32,6 @@
     "  os.environ['MKL_NUM_THREADS'] = str(threads)\n",
     "  os.environ['OMP_NUM_THREADS'] = str(threads)\n",
     "  return None\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/ML-python/fft-alignment-speed/fft-GPU.ipynb
+++ b/ML-python/fft-alignment-speed/fft-GPU.ipynb
@@ -28,7 +28,6 @@
     "import cupy  as np\n",
     "import pylab as plt\n",
     "import scipy as sp\n",
-    "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'retina'"
    ]
   },

--- a/ML-python/pandas-and-wine/wine-data.ipynb
+++ b/ML-python/pandas-and-wine/wine-data.ipynb
@@ -20,7 +20,6 @@
     "import pylab as plt\n",
     "import seaborn as sns\n",
     "from plt_style import *\n",
-    "%matplotlib inline\n",
     "sns.set()"
    ]
   },

--- a/ML-python/perceptron/rosenblatt_perceptron.ipynb
+++ b/ML-python/perceptron/rosenblatt_perceptron.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import rosen\n",
     "import pylab as plt\n",
     "import numpy as np\n",

--- a/data-python/numpy-example/Mandelbrot.ipynb
+++ b/data-python/numpy-example/Mandelbrot.ipynb
@@ -25,7 +25,6 @@
    "outputs": [],
    "source": [
     "# necessary imports\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "import pylab as plt"
    ]

--- a/data-python/pandas-and-wine/wine-data.ipynb
+++ b/data-python/pandas-and-wine/wine-data.ipynb
@@ -20,7 +20,6 @@
     "import pylab as plt\n",
     "import seaborn as sns\n",
     "from plt_style import *\n",
-    "%matplotlib inline\n",
     "sns.set()"
    ]
   },

--- a/data-python/vis-discovery/vis-discovery.ipynb
+++ b/data-python/vis-discovery/vis-discovery.ipynb
@@ -23,7 +23,6 @@
    "outputs": [],
    "source": [
     "# Import required modules\n",
-    "%matplotlib inline\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import glob,natsort\n",

--- a/intro-python/fft-gpu/fft-intel.ipynb
+++ b/intro-python/fft-gpu/fft-intel.ipynb
@@ -32,7 +32,6 @@
     "  os.environ['MKL_NUM_THREADS'] = str(threads)\n",
     "  os.environ['OMP_NUM_THREADS'] = str(threads)\n",
     "  return None\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/intro-python/fft-gpu/fft-nvidia.ipynb
+++ b/intro-python/fft-gpu/fft-nvidia.ipynb
@@ -28,7 +28,6 @@
     "import cupy  as np\n",
     "import pylab as plt\n",
     "import scipy as sp\n",
-    "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'retina'"
    ]
   },

--- a/intro-python/fft-gpu/rapids.ipynb
+++ b/intro-python/fft-gpu/rapids.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from plt_style import *\n",
     "from sklearn.datasets import make_circles\n",
     "import numpy,cupy\n",

--- a/intro-python/heat/heat.ipynb
+++ b/intro-python/heat/heat.ipynb
@@ -42,7 +42,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "import sys \n",
     "sys.path.append('../common')\n",
     "from plt_style import *\n",

--- a/intro-python/lorenz/Lorenz Differential Equations.ipynb
+++ b/intro-python/lorenz/Lorenz Differential Equations.ipynb
@@ -44,7 +44,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
    ]
   },
   {

--- a/intro-python/lorenz/Lorenz.ipynb
+++ b/intro-python/lorenz/Lorenz.ipynb
@@ -20,7 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "#from plt_style import *\n",
     "from ipywidgets import interactive, fixed\n",
     "from IPython.display import clear_output, display, HTML"

--- a/intro-python/rapids/rapids.ipynb
+++ b/intro-python/rapids/rapids.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import sys\n",
     "sys.path.append('../common')\n",
     "from plt_style import *\n",

--- a/intro-python/slides/IntroPython.ipynb
+++ b/intro-python/slides/IntroPython.ipynb
@@ -600,7 +600,6 @@
     "\n",
     "# plot the walk in the x-y plane\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
     "plt.plot(walk[:,0], walk[:,1])"
    ]
   },
@@ -748,8 +747,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt\n",
     "xs = np.arange(-1, 2, 0.1)\n",
     "plt.plot(xs, myfunc(xs))   # myfunc works on arrays too!\n",
     "plt.plot(root1[0], 0., 'ro')\n",

--- a/intro-python/stats/stats.ipynb
+++ b/intro-python/stats/stats.ipynb
@@ -19,7 +19,6 @@
    "outputs": [],
    "source": [
     "# Standard module imports and Jupyter magics\n",
-    "%matplotlib inline\n",
     "import sys\n",
     "sys.path.append('../common')\n",
     "from plt_style import *\n",


### PR DESCRIPTION
`%matplotlib inline` is no longer needed on Jupyter Notebooks.